### PR TITLE
Issue with tabmenu being transparent

### DIFF
--- a/web_design.css
+++ b/web_design.css
@@ -279,7 +279,7 @@ button:active, .wiki-page .wiki-page-content .wiki_button:active
 	left: 0;
 	padding: 0;
 	height: 44px;
-	background-color: transparent;
+	background-color: #fff;
 	border-bottom: 0 solid;
 	color: #999;
 	list-style-type: none;


### PR DESCRIPTION
The tabmenu's background was always white, but now incorrectly displays as transparent. In addition, there is another misplaced tabmenu in the header, which ought to be removed:

```
<h6><a href="http://www.reddit.com/r/web_design#top">home</a> <a href="http://www.reddit.com/r/web_design/hot">hot</a> <a href="http://www.reddit.com/r/web_design/new/">new</a> <a href="http://www.reddit.com/r/web_design/top/">top</a></h6>
```