### PR TITLE
Fixed rule qualification/hovering bug at line 2804

### DIFF
--- a/web_design.css
+++ b/web_design.css
@@ -2001,7 +2001,7 @@
 									}
 
 
-										.comment .expand:hover {
+										.comment.collapsed .expand:hover {
 											color: #fff;
 											text-decoration: none;
 											background-color: #4F8EF7;


### PR DESCRIPTION
The rule at line 2804,  ".comment .expand:hover",  is being overridden by reddit's default ".comment.collapsed .tagline, .comment.collapsed .tagline a {color:gray}" (line 4600 of reddit's stylesheet),   so that when a user hovers over the "[+]"(plus) of a collapsed comment, the hovering causes the background to go blue, but the plus sign would remain gray (it should turn white on hover).

This is resolved by strengthening the qualification of the rule in question by adding the ".collapsed" class to the ".comment" class, so that the rule reads as ".comment.collapsed .expand:hover", instead of just ".comment .expand:hover".

<img width="54" alt="screen shot 2015-07-31 at 8 48 13 pm" src="https://cloud.githubusercontent.com/assets/3777877/9020002/99e95098-37c5-11e5-805b-d259c6d21c06.png">
<img width="50" alt="screen shot 2015-07-31 at 8 48 58 pm" src="https://cloud.githubusercontent.com/assets/3777877/9020001/99e6e218-37c5-11e5-8c44-45108985abc3.png">

(This is my first GH contribution/edit ever, so please tell me if my commenting is inadequate in any way)