### PR TITLE
Remove unnecessary unit identifier

### DIFF
--- a/web_design.css
+++ b/web_design.css
@@ -70,7 +70,7 @@ body.listing-page>.content {margin-top: 45px;}
     color: #4D5763;
     font-weight: normal;
     text-decoration: none;
-    box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.24);
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.24);
 }
 
     .side .titlebox .md h6 a {


### PR DESCRIPTION
This super complex commit removes the px from 0px, because it is not necessary.

I may or may not be doing this for the Hacktoberfest...